### PR TITLE
Dynamic mode specification ("dev" or "prod")...

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -307,7 +307,11 @@ func fetch(this js.Value, args []js.Value) interface{} {
 		// TODO: If it's a GET request, is this still necessary / appropriate?
 		// In the switch statement below, all GET requests are given a body of '{}'. On arrival in the sever, this should actually be `undefined`.
 		if _, ok := userHeaderMap["Content-Type"]; !ok {
-			userHeaderMap["Content-Type"] = "application/json"
+			if options.Get("body").Call("constructor").Get("name").String() == "FormData" {
+				userHeaderMap["Content-Type"] = "multipart/form-data"
+			} else {
+				userHeaderMap["Content-Type"] = "application/json"
+			}
 		}
 
 		go func() {


### PR DESCRIPTION
### This PR allows:
- specification of a `mode` to determine whether to use a custom proxy URL for `dev` (usually localhost) or the remote proxy https://layer8proxy.net for `prod`
- tunnel establishment for multiple providers
- default `multipart/formdata` content type when `Formdata` is passed to body


### Tunnel initialization will now look like the following
**Production**
```js
layer8.initEncryptedTunnel({
    providers: ['localhost:6001']
});
```

**Development**
```js
layer8.initEncryptedTunnel({
    providers: ['localhost:6001'],
    proxy: 'http://localhost:5001'
}, 'dev');
```