### PR TITLE
Client side caching implementation and dynamic environment specification 

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -97,7 +97,7 @@ func persistenceCheck(this js.Value, args []js.Value) interface{} {
 	return promise
 }
 
-func parseURLForKey(u string) (string, error) {
+func getHost(u string) (string, error) {
 	p, err := url.Parse(u)
 	if err != nil {
 		return "", err
@@ -159,8 +159,9 @@ func initializeECDHTunnel(this js.Value, args []js.Value) interface{} {
 		reject := args[1]
 
 		initTunnel := func(provider string) {
-			// parse the provider URL to maintain a pattern
-			provider, err := parseURLForKey(provider)
+			// parse the provider URL to maintain a pattern of scheme://host:port
+			// in the L8Clients map
+			provider, err := getHost(provider)
 			if err != nil {
 				fmt.Println("[Interceptor]", err.Error())
 				EncryptedTunnelFlag = false
@@ -347,7 +348,7 @@ func fetch(this js.Value, args []js.Value) interface{} {
 			}
 		}
 
-		host, err := parseURLForKey(spURL)
+		host, err := getHost(spURL)
 		if err != nil {
 			reject.Invoke(js.Global().Get("Error").New(err.Error()))
 			return nil

--- a/interceptor.go
+++ b/interceptor.go
@@ -307,7 +307,11 @@ func fetch(this js.Value, args []js.Value) interface{} {
 		// TODO: If it's a GET request, is this still necessary / appropriate?
 		// In the switch statement below, all GET requests are given a body of '{}'. On arrival in the sever, this should actually be `undefined`.
 		if _, ok := userHeaderMap["Content-Type"]; !ok {
-			userHeaderMap["Content-Type"] = "application/json"
+			if options.Get("body").Call("constructor").Get("name").String() == "FormData" {
+				userHeaderMap["Content-Type"] = "multipart/form-data"
+			} else {
+				userHeaderMap["Content-Type"] = "application/json"
+			}
 		}
 
 		go func() {

--- a/interceptor.go
+++ b/interceptor.go
@@ -262,7 +262,7 @@ func initializeECDHTunnel(this js.Value, args []js.Value) interface{} {
 				}
 			}
 			L8Clients[provider] = internals.NewClient(proxyURL.Scheme, proxyURL.Hostname(), port)
-			fmt.Sprintln("[%s] Encrypted tunnel successfully established.", provider)
+			fmt.Printf("[%s] Encrypted tunnel successfully established.\n", provider)
 			resolve.Invoke(true)
 			return
 		}


### PR DESCRIPTION
### This PR allows:
- caching of static files
- specification of a `mode` to determine whether to use a custom proxy URL for `dev` (usually localhost) or the remote proxy https://layer8proxy.net for `prod`
- tunnel establishment for multiple providers
- default `multipart/formdata` content type when `Formdata` is passed to body


### Tunnel initialization will now look like the following
**Production**
```js
layer8.initEncryptedTunnel({
    providers: ['http://localhost:6001']
});
```

**Development**
```js
layer8.initEncryptedTunnel({
    providers: ['http://localhost:6001'],
    proxy: 'http://localhost:5001'
}, 'dev');
```