### PR TITLE
[DRAFT] Url path extraction and encryption at the User side #23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,5 @@ dist
 .pnp.*
 
 /bin/interceptor.wasm
+
+.vscode

--- a/interceptor.go
+++ b/interceptor.go
@@ -459,16 +459,21 @@ func fetch(this js.Value, args []js.Value) interface{} {
 				// Converting the body to Golag or setting it as null/nil
 				bodyMap := map[string]interface{}{}
 				body := options.Get("body")
+				urlPath := strings.Replace(spURL, host, "", 1)
+				// fmt.Println("[Interceptor] URL Path: ", urlPath) // For debugging purposes
 				if body.String() == "<undefined>" {
 					// body = js.ValueOf(map[string]interface{}{}) <= this will err out as "Uncaught (in promise) Error: invalid character '<' looking for beginning of value"
 					body = js.ValueOf("{}")
+					bodyMap["url_path"] = urlPath
 				} else {
 					err := json.Unmarshal([]byte(body.String()), &bodyMap)
 					if err != nil {
 						reject.Invoke(js.Global().Get("Error").New(err.Error()))
 						return
 					}
+					bodyMap["url_path"] = urlPath
 				}
+				// fmt.Println("[Interceptor] BodyMap: ", bodyMap) // For debugging purposes
 				// encode the body to json
 				bodyByte, err := json.Marshal(bodyMap)
 				if err != nil {

--- a/internals/main.go
+++ b/internals/main.go
@@ -158,7 +158,9 @@ func (c *Client) do(
 	}
 	// create request
 	client := &http.Client{}
-	r, err := http.NewRequest("POST", c.proxyURL+parsedURL.Path, bytes.NewBuffer(data))
+	// !NOTE: GET Requests are also converted to POST requests
+	// fmt.Println("[Interceptor] c.proxyURL+parsedURL.Path: ", c.proxyURL+parsedURL.Path+parsedURL.RawQuery) // For debugging purposes
+	r, err := http.NewRequest("POST", c.proxyURL, bytes.NewBuffer(data))
 	if err != nil {
 		res := &utils.Response{
 			Status:     500,
@@ -168,6 +170,7 @@ func (c *Client) do(
 		resByte, _ := res.ToJSON()
 		return resByte
 	}
+
 	// Add headers to the interceptor request.
 	// Note that at this point, the user's headers are bundled into the encrypted body of the interceptor's request
 	r.Header.Add("X-Forwarded-Host", parsedURL.Host)


### PR DESCRIPTION
NOTE: Still need to do some tests with queries in the URL parameter.

## PR Description
Made changes at interceptor to extracr the URL path from the host (SP Backend URL), and move that path into the body and encrypt it, which will go all the way to the middleware.

Issue: https://github.com/globe-and-citizen/layer8/issues/65

## Manual Test Suite
SECTION 1: WEVE GOT POEMS (http://localhost:5173/)
[ ] Log in with 'tester' / '1234'
[ ] Log in anonymously with Layer8
[ ] Clicking "Get Next Poem" loads different poem correctly x 3
[ ] Clicking "Logout" takes you to the login screen
[ ] Clicking "Register" takes you to the registration page
[ ] Registering with a username, password, and profile image is successful
[ ] Logging in with the new username / password succeeds
[ ] Logging in with Layer8 opens the pop-up
[ ] Logging in with the "tester" & "12341234" works
[ ] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
[ ] Clicking "Get Next Poem" loads different poem correctly x 3
[ ] Clicking "Logout" takes you to the login page

SECTION 2: IMSHARER (http://localhost:5174/)
[ ] Main page loads
[ ] Upload of image works
[ ] Reload leads to instant reload (demonstrating proper caching)
[ ] Clicking the newly loaded image shows it in a light boxLog in using tester and 12341234 should succeed
