### PR TITLE
[Hmk/url encryption] Made changes to interceptor to extract and encrypt path and query params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,5 @@ dist
 .pnp.*
 
 /bin/interceptor.wasm
+
+.vscode

--- a/interceptor.go
+++ b/interceptor.go
@@ -465,7 +465,6 @@ func fetch(this js.Value, args []js.Value) interface{} {
 					// body = js.ValueOf(map[string]interface{}{}) <= this will err out as "Uncaught (in promise) Error: invalid character '<' looking for beginning of value"
 					body = js.ValueOf("{}")
 					bodyMap["url_path"] = urlPath
-					// bodyMap["query_params"] = map[sting]sting {"id": "2"}
 				} else {
 					err := json.Unmarshal([]byte(body.String()), &bodyMap)
 					if err != nil {

--- a/interceptor.go
+++ b/interceptor.go
@@ -464,14 +464,14 @@ func fetch(this js.Value, args []js.Value) interface{} {
 				if body.String() == "<undefined>" {
 					// body = js.ValueOf(map[string]interface{}{}) <= this will err out as "Uncaught (in promise) Error: invalid character '<' looking for beginning of value"
 					body = js.ValueOf("{}")
-					bodyMap["url_path"] = urlPath
+					bodyMap["__url_path"] = urlPath
 				} else {
 					err := json.Unmarshal([]byte(body.String()), &bodyMap)
 					if err != nil {
 						reject.Invoke(js.Global().Get("Error").New(err.Error()))
 						return
 					}
-					bodyMap["url_path"] = urlPath
+					bodyMap["__url_path"] = urlPath
 				}
 				// fmt.Println("[Interceptor] BodyMap: ", bodyMap) // For debugging purposes
 				// encode the body to json

--- a/interceptor.go
+++ b/interceptor.go
@@ -457,21 +457,21 @@ func fetch(this js.Value, args []js.Value) interface{} {
 			switch strings.ToLower(userHeaderMap["Content-Type"]) {
 			case "application/json": // Note this is the default that GET requests travel through
 				// Converting the body to Golag or setting it as null/nil
-				bodyMap := map[string]interface{}{}
-				body := options.Get("body")
 				urlPath := strings.Replace(spURL, host, "", 1)
+				bodyMap := map[string]interface{}{
+					"__url_path": urlPath,
+				}
+				body := options.Get("body")
 				// fmt.Println("[Interceptor] URL Path: ", urlPath) // For debugging purposes
 				if body.String() == "<undefined>" {
 					// body = js.ValueOf(map[string]interface{}{}) <= this will err out as "Uncaught (in promise) Error: invalid character '<' looking for beginning of value"
 					body = js.ValueOf("{}")
-					bodyMap["__url_path"] = urlPath
 				} else {
 					err := json.Unmarshal([]byte(body.String()), &bodyMap)
 					if err != nil {
 						reject.Invoke(js.Global().Get("Error").New(err.Error()))
 						return
 					}
-					bodyMap["__url_path"] = urlPath
 				}
 				// fmt.Println("[Interceptor] BodyMap: ", bodyMap) // For debugging purposes
 				// encode the body to json

--- a/interceptor.go
+++ b/interceptor.go
@@ -465,6 +465,7 @@ func fetch(this js.Value, args []js.Value) interface{} {
 					// body = js.ValueOf(map[string]interface{}{}) <= this will err out as "Uncaught (in promise) Error: invalid character '<' looking for beginning of value"
 					body = js.ValueOf("{}")
 					bodyMap["url_path"] = urlPath
+					// bodyMap["query_params"] = map[sting]sting {"id": "2"}
 				} else {
 					err := json.Unmarshal([]byte(body.String()), &bodyMap)
 					if err != nil {

--- a/interceptor.go
+++ b/interceptor.go
@@ -459,16 +459,21 @@ func fetch(this js.Value, args []js.Value) interface{} {
 				// Converting the body to Golag or setting it as null/nil
 				bodyMap := map[string]interface{}{}
 				body := options.Get("body")
+				urlPath := strings.Replace(spURL, host, "", 1)
+				// fmt.Println("[Interceptor] URL Path: ", urlPath) // For debugging purposes
 				if body.String() == "<undefined>" {
 					// body = js.ValueOf(map[string]interface{}{}) <= this will err out as "Uncaught (in promise) Error: invalid character '<' looking for beginning of value"
 					body = js.ValueOf("{}")
+					bodyMap["url_path"] = urlPath
 				} else {
 					err := json.Unmarshal([]byte(body.String()), &bodyMap)
 					if err != nil {
 						reject.Invoke(js.Global().Get("Error").New(err.Error()))
 						return
 					}
+					bodyMap["url_path"] = urlPath
 				}
+				// fmt.Println("[Interceptor] BodyMap: ", bodyMap) // For debugging purposes
 				// encode the body to json
 				bodyByte, err := json.Marshal(bodyMap)
 				if err != nil {

--- a/internals/main.go
+++ b/internals/main.go
@@ -158,7 +158,9 @@ func (c *Client) do(
 	}
 	// create request
 	client := &http.Client{}
-	r, err := http.NewRequest("POST", c.proxyURL+parsedURL.Path, bytes.NewBuffer(data))
+	// !NOTE: GET Requests are also converted to POST requests
+	// fmt.Println("[Interceptor] c.proxyURL+parsedURL.Path: ", c.proxyURL+parsedURL.Path+parsedURL.RawQuery) // For debugging purposes
+	r, err := http.NewRequest("POST", c.proxyURL, bytes.NewBuffer(data))
 	if err != nil {
 		res := &utils.Response{
 			Status:     500,
@@ -168,6 +170,7 @@ func (c *Client) do(
 		resByte, _ := res.ToJSON()
 		return resByte
 	}
+
 	// Add headers to the interceptor request.
 	// Note that at this point, the user's headers are bundled into the encrypted body of the interceptor's request
 	r.Header.Add("X-Forwarded-Host", parsedURL.Host)

--- a/internals/main.go
+++ b/internals/main.go
@@ -159,7 +159,7 @@ func (c *Client) do(
 	// create request
 	client := &http.Client{}
 	// !NOTE: GET Requests are also converted to POST requests
-	// fmt.Println("[Interceptor] c.proxyURL+parsedURL.Path: ", c.proxyURL+parsedURL.Path+parsedURL.RawQuery) // For debugging purposes
+	// fmt.Println("[Interceptor] c.proxyURL+parsedURL.Path: ", c.proxyURL+parsedURL.Path+"?"+parsedURL.RawQuery) // For debugging purposes
 	r, err := http.NewRequest("POST", c.proxyURL, bytes.NewBuffer(data))
 	if err != nil {
 		res := &utils.Response{

--- a/internals/main_test.go
+++ b/internals/main_test.go
@@ -64,7 +64,7 @@ func TestClientDo(t *testing.T) {
 
 	var (
 		RequestMethod  = "GET"
-		RequestURL     = "https://test.layer8.com/test"
+		RequestURL     = "https://test.layer8.com/"
 		RequestHeaders = map[string]string{
 			"Content-Type":  "application/json",
 			"X-Test-Header": "test",


### PR DESCRIPTION
## PR Description
This PR is related to issue: https://github.com/globe-and-citizen/layer8/issues/65 , now at the interceptor, the path and query params, are going to be removed from the URL, and this will go into the body, in the form of map to string, which is later encrypted at the interceptor. From interceptor, each request to the SP BE will go as `/`, no path and queries visible to the layer8 proxy, and proxy just forwards it to the SP BE, but here is the main part, before reaching to the BE, the middleware comes in place, and decrypts the body, add path, and query params back to the url, and the request continues as normal like nothing happened and SP BE don't know what was happening behind the scene, it receives request like normal, and the flow continue backwards then.

## Manual Test Suite
SECTION 1: WEVE GOT POEMS (http://localhost:5173/)
- [x] Log in with 'tester' / '1234'
- [x] Log in anonymously with Layer8
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login screen
- [x] Clicking "Register" takes you to the registration page
- [x] Registering with a username, password, and profile image is successful
- [x] Logging in with the new username / password succeeds
- [x] Logging in with Layer8 opens the pop-up
- [x] Logging in with the "tester" & "12341234" works
- [x] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login page

SECTION 2: IMSHARER (http://localhost:5174/)
- [x] Main page loads
- [x] Upload of image works
- [x] Reload leads to instant reload (demonstrating proper caching)
- [x] Clicking the newly loaded image shows it in a light boxLog in using tester and 12341234 should succeed

Tested a local version of this interceptor, with this a local version of this middleware: https://github.com/globe-and-citizen/layer8-middleware/tree/hmk/url-encryption
